### PR TITLE
Encryption

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,7 +16,7 @@ android {
         minSdk = 30
         targetSdk = 36
         versionCode = 1
-        versionName = "2.0.9-BETA"
+        versionName = "2.0.10-BETA"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/sameerasw/airsync/MainActivity.kt
+++ b/app/src/main/java/com/sameerasw/airsync/MainActivity.kt
@@ -39,30 +39,22 @@ class MainActivity : ComponentActivity() {
         // Parse QR code parameters
         var pcName: String? = null
         var isPlus = false
+        var symmetricKey: String? = null
 
         data?.let { uri ->
-            val query = uri.query
-            if (query != null) {
-                // Split on first occurrence of "?plus="
-                if (query.contains("?plus=")) {
-                    val parts = query.split("?plus=", limit = 2)
-                    if (parts.size == 2) {
-                        // Extract name part
-                        val namePart = parts[0]
-                        if (namePart.startsWith("name=")) {
-                            pcName = URLDecoder.decode(namePart.substring(5), "UTF-8")
-                        }
-
-                        // Extract plus value
-                        isPlus = parts[1].toBooleanStrictOrNull() ?: false
-                    }
-                } else {
-                    // Fallback to standard parameter parsing
-                    pcName = uri.getQueryParameter("name")?.let {
-                        URLDecoder.decode(it, "UTF-8")
-                    }
-                    isPlus = uri.getQueryParameter("plus")?.toBooleanStrictOrNull() ?: false
+            val urlString = uri.toString()
+            val queryPart = urlString.substringAfter('?', "")
+            if (queryPart.isNotEmpty()) {
+                val params = queryPart.split('?')
+                val paramMap = params.associate {
+                    val parts = it.split('=', limit = 2)
+                    val key = parts.getOrNull(0) ?: ""
+                    val value = parts.getOrNull(1) ?: ""
+                    key to value
                 }
+                pcName = paramMap["name"]?.let { URLDecoder.decode(it, "UTF-8") }
+                isPlus = paramMap["plus"]?.toBooleanStrictOrNull() ?: false
+                symmetricKey = paramMap["key"]
             }
         }
 
@@ -85,6 +77,7 @@ class MainActivity : ComponentActivity() {
                                 showConnectionDialog = isFromQrScan,
                                 pcName = pcName,
                                 isPlus = isPlus,
+                                symmetricKey = symmetricKey,
                                 onNavigateToApps = {
                                     navController.navigate("notification_apps")
                                 },

--- a/app/src/main/java/com/sameerasw/airsync/data/local/DataStoreManager.kt
+++ b/app/src/main/java/com/sameerasw/airsync/data/local/DataStoreManager.kt
@@ -28,6 +28,7 @@ class DataStoreManager(private val context: Context) {
         private val LAST_CONNECTED_PC_PORT = stringPreferencesKey("last_connected_pc_port")
         private val LAST_CONNECTED_TIMESTAMP = stringPreferencesKey("last_connected_timestamp")
         private val LAST_CONNECTED_PC_PLUS = booleanPreferencesKey("last_connected_pc_plus")
+        private val LAST_CONNECTED_SYMMETRIC_KEY = stringPreferencesKey("last_connected_symmetric_key")
         private val LAST_SYNC_TIME = stringPreferencesKey("last_sync_time")
         private val NOTIFICATION_SYNC_ENABLED = booleanPreferencesKey("notification_sync_enabled")
         private val DEVELOPER_MODE = booleanPreferencesKey("developer_mode")
@@ -132,6 +133,9 @@ class DataStoreManager(private val context: Context) {
             preferences[LAST_CONNECTED_PC_PORT] = device.port
             preferences[LAST_CONNECTED_TIMESTAMP] = device.lastConnected.toString()
             preferences[LAST_CONNECTED_PC_PLUS] = device.isPlus
+            device.symmetricKey?.let {
+                preferences[LAST_CONNECTED_SYMMETRIC_KEY] = it
+            }
             preferences[ICON_SYNC_COUNT] = device.iconSyncCount.toString()
             device.lastIconSyncDate?.let {
                 preferences[LAST_ICON_SYNC_DATE] = it
@@ -149,6 +153,7 @@ class DataStoreManager(private val context: Context) {
             val port = preferences[LAST_CONNECTED_PC_PORT]
             val timestamp = preferences[LAST_CONNECTED_TIMESTAMP]
             val isPlus = preferences[LAST_CONNECTED_PC_PLUS] ?: false
+            val symmetricKey = preferences[LAST_CONNECTED_SYMMETRIC_KEY]
             val lastSyncTime = preferences[LAST_SYNC_TIME]?.toLongOrNull()
             val iconSyncCount = preferences[ICON_SYNC_COUNT]?.toIntOrNull() ?: 0
             val lastIconSyncDate = preferences[LAST_ICON_SYNC_DATE]
@@ -162,7 +167,8 @@ class DataStoreManager(private val context: Context) {
                     lastSyncTime = lastSyncTime,
                     isPlus = isPlus,
                     iconSyncCount = iconSyncCount,
-                    lastIconSyncDate = lastIconSyncDate
+                    lastIconSyncDate = lastIconSyncDate,
+                    symmetricKey = symmetricKey
                 )
             } else {
                 null
@@ -268,7 +274,7 @@ class DataStoreManager(private val context: Context) {
     }
 
     // Network-aware device connections
-    suspend fun saveNetworkDeviceConnection(deviceName: String, ourIp: String, clientIp: String, port: String, isPlus: Boolean) {
+    suspend fun saveNetworkDeviceConnection(deviceName: String, ourIp: String, clientIp: String, port: String, isPlus: Boolean, symmetricKey: String?) {
         context.dataStore.edit { preferences ->
             // Load existing connections for this device
             val existingConnectionsJson = preferences[stringPreferencesKey("${NETWORK_CONNECTIONS_PREFIX}${deviceName}")] ?: "{}"
@@ -293,6 +299,9 @@ class DataStoreManager(private val context: Context) {
             preferences[stringPreferencesKey("${NETWORK_DEVICES_PREFIX}${deviceName}_name")] = deviceName
             preferences[stringPreferencesKey("${NETWORK_DEVICES_PREFIX}${deviceName}_port")] = port
             preferences[booleanPreferencesKey("${NETWORK_DEVICES_PREFIX}${deviceName}_plus")] = isPlus
+            symmetricKey?.let {
+                preferences[stringPreferencesKey("${NETWORK_DEVICES_PREFIX}${deviceName}_symmetric_key")] = it
+            }
             preferences[stringPreferencesKey("${NETWORK_DEVICES_PREFIX}${deviceName}_last_connected")] = System.currentTimeMillis().toString()
             preferences[stringPreferencesKey("${NETWORK_CONNECTIONS_PREFIX}${deviceName}")] = updatedJson
         }
@@ -303,6 +312,7 @@ class DataStoreManager(private val context: Context) {
             val name = preferences[stringPreferencesKey("${NETWORK_DEVICES_PREFIX}${deviceName}_name")]
             val port = preferences[stringPreferencesKey("${NETWORK_DEVICES_PREFIX}${deviceName}_port")]
             val isPlus = preferences[booleanPreferencesKey("${NETWORK_DEVICES_PREFIX}${deviceName}_plus")] ?: false
+            val symmetricKey = preferences[stringPreferencesKey("${NETWORK_DEVICES_PREFIX}${deviceName}_symmetric_key")]
             val lastConnected = preferences[stringPreferencesKey("${NETWORK_DEVICES_PREFIX}${deviceName}_last_connected")]?.toLongOrNull() ?: 0L
             val connectionsJson = preferences[stringPreferencesKey("${NETWORK_CONNECTIONS_PREFIX}${deviceName}")] ?: "{}"
 
@@ -323,7 +333,8 @@ class DataStoreManager(private val context: Context) {
                     networkConnections = connections,
                     port = port,
                     lastConnected = lastConnected,
-                    isPlus = isPlus
+                    isPlus = isPlus,
+                    symmetricKey = symmetricKey
                 )
             } else {
                 null
@@ -349,6 +360,7 @@ class DataStoreManager(private val context: Context) {
                 val name = preferences[stringPreferencesKey("${NETWORK_DEVICES_PREFIX}${deviceName}_name")]
                 val port = preferences[stringPreferencesKey("${NETWORK_DEVICES_PREFIX}${deviceName}_port")]
                 val isPlus = preferences[booleanPreferencesKey("${NETWORK_DEVICES_PREFIX}${deviceName}_plus")] ?: false
+                val symmetricKey = preferences[stringPreferencesKey("${NETWORK_DEVICES_PREFIX}${deviceName}_symmetric_key")]
                 val lastConnected = preferences[stringPreferencesKey("${NETWORK_DEVICES_PREFIX}${deviceName}_last_connected")]?.toLongOrNull() ?: 0L
                 val connectionsJson = preferences[stringPreferencesKey("${NETWORK_CONNECTIONS_PREFIX}${deviceName}")] ?: "{}"
 
@@ -370,7 +382,8 @@ class DataStoreManager(private val context: Context) {
                             networkConnections = connections,
                             port = port,
                             lastConnected = lastConnected,
-                            isPlus = isPlus
+                            isPlus = isPlus,
+                            symmetricKey = symmetricKey
                         )
                     )
                 }

--- a/app/src/main/java/com/sameerasw/airsync/data/repository/AirSyncRepositoryImpl.kt
+++ b/app/src/main/java/com/sameerasw/airsync/data/repository/AirSyncRepositoryImpl.kt
@@ -76,8 +76,8 @@ class AirSyncRepositoryImpl(
     }
 
     // Network-aware device connections
-    override suspend fun saveNetworkDeviceConnection(deviceName: String, ourIp: String, clientIp: String, port: String, isPlus: Boolean) {
-        dataStoreManager.saveNetworkDeviceConnection(deviceName, ourIp, clientIp, port, isPlus)
+    override suspend fun saveNetworkDeviceConnection(deviceName: String, ourIp: String, clientIp: String, port: String, isPlus: Boolean, symmetricKey: String?) {
+        dataStoreManager.saveNetworkDeviceConnection(deviceName, ourIp, clientIp, port, isPlus, symmetricKey)
     }
 
     override fun getNetworkDeviceConnection(deviceName: String): Flow<NetworkDeviceConnection?> {

--- a/app/src/main/java/com/sameerasw/airsync/domain/model/Models.kt
+++ b/app/src/main/java/com/sameerasw/airsync/domain/model/Models.kt
@@ -20,7 +20,8 @@ data class UiState(
     val isConnecting: Boolean = false,
     val isClipboardSyncEnabled: Boolean = true,
     val isIconSyncLoading: Boolean = false,
-    val iconSyncMessage: String = ""
+    val iconSyncMessage: String = "",
+    val symmetricKey: String? = null
 )
 
 data class DeviceInfo(
@@ -36,18 +37,17 @@ data class ConnectedDevice(
     val lastSyncTime: Long? = null,
     val isPlus: Boolean = false,
     val iconSyncCount: Int = 0,
-    val lastIconSyncDate: String? = null
+    val lastIconSyncDate: String? = null,
+    val symmetricKey: String? = null
 )
 
 data class NetworkDeviceConnection(
     val deviceName: String,
-    val networkConnections: Map<String, String>,
+    val networkConnections: Map<String, String>, // Map of our IP -> client IP
     val port: String,
     val lastConnected: Long,
-    val lastSyncTime: Long? = null,
-    val isPlus: Boolean = false,
-    val iconSyncCount: Int = 0,
-    val lastIconSyncDate: String? = null
+    val isPlus: Boolean,
+    val symmetricKey: String? = null
 ) {
     // get client IP for current network
     fun getClientIpForNetwork(ourIp: String): String? {
@@ -61,12 +61,10 @@ data class NetworkDeviceConnection(
             ConnectedDevice(
                 name = deviceName,
                 ipAddress = clientIp,
-                port = port,
-                lastConnected = lastConnected,
-                lastSyncTime = lastSyncTime,
-                isPlus = isPlus,
-                iconSyncCount = iconSyncCount,
-                lastIconSyncDate = lastIconSyncDate
+                port = this.port,
+                lastConnected = this.lastConnected,
+                isPlus = this.isPlus,
+                symmetricKey = this.symmetricKey
             )
         } else null
     }

--- a/app/src/main/java/com/sameerasw/airsync/domain/repository/AirSyncRepository.kt
+++ b/app/src/main/java/com/sameerasw/airsync/domain/repository/AirSyncRepository.kt
@@ -31,7 +31,7 @@ interface AirSyncRepository {
     fun getLastConnectedDevice(): Flow<ConnectedDevice?>
 
     // Network-aware device connections
-    suspend fun saveNetworkDeviceConnection(deviceName: String, ourIp: String, clientIp: String, port: String, isPlus: Boolean)
+    suspend fun saveNetworkDeviceConnection(deviceName: String, ourIp: String, clientIp: String, port: String, isPlus: Boolean, symmetricKey: String?)
     fun getNetworkDeviceConnection(deviceName: String): Flow<NetworkDeviceConnection?>
     fun getAllNetworkDeviceConnections(): Flow<List<NetworkDeviceConnection>>
     suspend fun updateNetworkDeviceLastConnected(deviceName: String, timestamp: Long)

--- a/app/src/main/java/com/sameerasw/airsync/presentation/ui/activities/ShareActivity.kt
+++ b/app/src/main/java/com/sameerasw/airsync/presentation/ui/activities/ShareActivity.kt
@@ -32,36 +32,36 @@ class ShareActivity : ComponentActivity() {
                 if (sharedText != null) {
                     val dataStoreManager = DataStoreManager(this@ShareActivity)
 
-                    // Check if clipboard sync is enabled
-                    val isClipboardSyncEnabled = dataStoreManager.getClipboardSyncEnabled().first()
+                    // Try to connect if not already connected
+                    if (!WebSocketUtil.isConnected()) {
+                        val ipAddress = dataStoreManager.getIpAddress().first()
+                        val port = dataStoreManager.getPort().first().toIntOrNull() ?: 6996
+                        val lastConnectedDevice = dataStoreManager.getLastConnectedDevice().first()
+                        val symmetricKey = lastConnectedDevice?.symmetricKey
 
-                        // Try to connect if not already connected
-                        if (!WebSocketUtil.isConnected()) {
-                            val ipAddress = dataStoreManager.getIpAddress().first()
-                            val port = dataStoreManager.getPort().first().toIntOrNull() ?: 6996
-
-                            WebSocketUtil.connect(
-                                context = this@ShareActivity,
-                                ipAddress = ipAddress,
-                                port = port,
-                                onConnectionStatus = { connected ->
-                                    if (connected) {
-                                        // Send text after connection
-                                        ClipboardSyncManager.syncTextToDesktop(sharedText)
-                                        showToast("Text shared to PC")
-                                    } else {
-                                        showToast("Failed to connect to PC")
-                                    }
-                                    finish()
-                                },
-                                onMessage = { }
-                            )
-                        } else {
-                            // Already connected, send directly
-                            ClipboardSyncManager.syncTextToDesktop(sharedText)
-                            showToast("Text shared to PC")
-                            finish()
-                        }
+                        WebSocketUtil.connect(
+                            context = this@ShareActivity,
+                            ipAddress = ipAddress,
+                            port = port,
+                            symmetricKey = symmetricKey,
+                            onConnectionStatus = { connected ->
+                                if (connected) {
+                                    // Send text after connection
+                                    ClipboardSyncManager.syncTextToDesktop(sharedText)
+                                    showToast("Text shared to PC")
+                                } else {
+                                    showToast("Failed to connect to PC")
+                                }
+                                finish()
+                            },
+                            onMessage = { }
+                        )
+                    } else {
+                        // Already connected, send directly
+                        ClipboardSyncManager.syncTextToDesktop(sharedText)
+                        showToast("Text shared to PC")
+                        finish()
+                    }
                 } else {
                     showToast("No text to share")
                     finish()

--- a/app/src/main/java/com/sameerasw/airsync/presentation/ui/screens/AirSyncMainScreen.kt
+++ b/app/src/main/java/com/sameerasw/airsync/presentation/ui/screens/AirSyncMainScreen.kt
@@ -47,6 +47,7 @@ fun AirSyncMainScreen(
     showConnectionDialog: Boolean = false,
     pcName: String? = null,
     isPlus: Boolean = false,
+    symmetricKey: String? = null,
     onNavigateToApps: () -> Unit = {},
     onRequestNotificationPermission: () -> Unit = {}
 ) {
@@ -75,7 +76,7 @@ fun AirSyncMainScreen(
     var showAboutDialog by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
-        viewModel.initializeState(context, initialIp, initialPort, showConnectionDialog && !hasProcessedQrDialog, pcName, isPlus)
+        viewModel.initializeState(context, initialIp, initialPort, showConnectionDialog && !hasProcessedQrDialog, pcName, isPlus, symmetricKey)
 
         // Check for updates on app start (silently)
         viewModel.checkForUpdates(context, showDialogOnUpdate = false)
@@ -123,6 +124,7 @@ fun AirSyncMainScreen(
             context = context,
             ipAddress = uiState.ipAddress,
             port = uiState.port.toIntOrNull() ?: 6996,
+            symmetricKey = uiState.symmetricKey,
             onConnectionStatus = { connected ->
                 scope.launch(Dispatchers.Main) {
                     viewModel.setConnectionStatus(isConnected = connected, isConnecting = false)
@@ -130,7 +132,7 @@ fun AirSyncMainScreen(
                         viewModel.setResponse("Connected successfully!")
                         // Get plus status from current temporary device or use QR code value
                         val plusStatus = uiState.lastConnectedDevice?.isPlus ?: isPlus
-                        viewModel.saveLastConnectedDevice(pcName, plusStatus)
+                        viewModel.saveLastConnectedDevice(pcName, plusStatus, uiState.symmetricKey)
                     } else {
                         viewModel.setResponse("Failed to connect")
                     }
@@ -322,6 +324,7 @@ fun AirSyncMainScreen(
                                 // Fallback to legacy stored device
                                 viewModel.updateIpAddress(device.ipAddress)
                                 viewModel.updatePort(device.port)
+                                viewModel.updateSymmetricKey(device.symmetricKey)
                                 connect()
                             }
                         }

--- a/app/src/main/java/com/sameerasw/airsync/service/AirSyncTileService.kt
+++ b/app/src/main/java/com/sameerasw/airsync/service/AirSyncTileService.kt
@@ -83,6 +83,7 @@ class AirSyncTileService : TileService() {
                     context = this@AirSyncTileService,
                     ipAddress = lastDevice.ipAddress,
                     port = lastDevice.port.toIntOrNull() ?: 6996,
+                    symmetricKey = lastDevice.symmetricKey,
                     onConnectionStatus = { connected ->
                         serviceScope.launch {
                             updateTileState()
@@ -94,21 +95,13 @@ class AirSyncTileService : TileService() {
                 val intent = Intent(this, MainActivity::class.java).apply {
                     flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
                 }
-
-                // Use API level appropriate method
-                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                    val pendingIntent = PendingIntent.getActivity(
-                        this@AirSyncTileService,
-                        0,
-                        intent,
-                        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-                    )
-                    startActivityAndCollapse(pendingIntent)
-                } else {
-                    // Use deprecated method for older API levels
-                    @Suppress("DEPRECATION")
-                    startActivityAndCollapse(intent)
-                }
+                val pendingIntent = PendingIntent.getActivity(
+                    this@AirSyncTileService,
+                    0,
+                    intent,
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                )
+                startActivityAndCollapse(pendingIntent)
             }
         } catch (e: Exception) {
             Log.e(TAG, "Error connecting to last device", e)

--- a/app/src/main/java/com/sameerasw/airsync/utils/CryptoUtil.kt
+++ b/app/src/main/java/com/sameerasw/airsync/utils/CryptoUtil.kt
@@ -1,0 +1,64 @@
+package com.sameerasw.airsync.utils
+
+import android.util.Base64
+import java.nio.charset.StandardCharsets
+import java.security.SecureRandom
+import javax.crypto.Cipher
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+object CryptoUtil {
+
+    private const val AES_GCM_NOPADDING = "AES/GCM/NoPadding"
+    private const val NONCE_SIZE_BYTES = 12
+    private const val TAG_SIZE_BITS = 128
+
+    fun decodeKey(base64Key: String): SecretKey {
+        val keyBytes = Base64.decode(base64Key, Base64.DEFAULT)
+        return SecretKeySpec(keyBytes, "AES")
+    }
+
+    fun decryptMessage(base64Combined: String, key: SecretKey): String? {
+        return try {
+            val combined = Base64.decode(base64Combined, Base64.DEFAULT)
+
+            if (combined.size < NONCE_SIZE_BYTES) {
+                return null // Invalid message
+            }
+
+            val nonce = combined.copyOfRange(0, NONCE_SIZE_BYTES)
+            val ciphertextWithTag = combined.copyOfRange(NONCE_SIZE_BYTES, combined.size)
+
+            val cipher = Cipher.getInstance(AES_GCM_NOPADDING)
+            val spec = GCMParameterSpec(TAG_SIZE_BITS, nonce)
+            cipher.init(Cipher.DECRYPT_MODE, key, spec)
+
+            val plainBytes = cipher.doFinal(ciphertextWithTag)
+            String(plainBytes, StandardCharsets.UTF_8)
+        } catch (e: Exception) {
+            e.printStackTrace()
+            null
+        }
+    }
+
+    fun encryptMessage(message: String, key: SecretKey): String? {
+        return try {
+            val nonce = ByteArray(NONCE_SIZE_BYTES)
+            SecureRandom().nextBytes(nonce)
+
+            val cipher = Cipher.getInstance(AES_GCM_NOPADDING)
+            val spec = GCMParameterSpec(TAG_SIZE_BITS, nonce)
+            cipher.init(Cipher.ENCRYPT_MODE, key, spec)
+
+            val ciphertext = cipher.doFinal(message.toByteArray(StandardCharsets.UTF_8))
+
+            val combined = nonce + ciphertext
+            Base64.encodeToString(combined, Base64.NO_WRAP)
+        } catch (e: Exception) {
+            e.printStackTrace()
+            null
+        }
+    }
+}
+


### PR DESCRIPTION
This pull request introduces support for handling a symmetric key as part of device connections, improving secure communication between devices. The changes propagate the `symmetricKey` parameter throughout the app’s data flow, from QR code parsing to data models, persistence, and connection logic. Additionally, the app version is incremented.

**Symmetric Key Support and Propagation**

* Added `symmetricKey` extraction from QR code URIs in `MainActivity`, passing it through the UI and ViewModel layers (`MainActivity.kt`, `AirSyncMainScreen.kt`, `AirSyncViewModel.kt`). [[1]](diffhunk://#diff-9599eb412ac9a320fe5271e584b04752e16762ea662710b4f595ad9541293824R42-R57) [[2]](diffhunk://#diff-9599eb412ac9a320fe5271e584b04752e16762ea662710b4f595ad9541293824R80) [[3]](diffhunk://#diff-de07ef3d8e1abd4ac4e10a4d548cc754aa1a1319a9c14c148821c54316333807R50) [[4]](diffhunk://#diff-de07ef3d8e1abd4ac4e10a4d548cc754aa1a1319a9c14c148821c54316333807L78-R79) [[5]](diffhunk://#diff-16e2711b11e71d6f9411c9307b5e0771d96bf2352592d798a9f5385a8145e894L93-R94) [[6]](diffhunk://#diff-16e2711b11e71d6f9411c9307b5e0771d96bf2352592d798a9f5385a8145e894R105)
* Updated data models (`UiState`, `ConnectedDevice`, `NetworkDeviceConnection`) to include an optional `symmetricKey` field. [[1]](diffhunk://#diff-853cf88526a68a37dc6cd436a86ae63862f5a871723ebf9c540c48946f557ddbL23-R24) [[2]](diffhunk://#diff-853cf88526a68a37dc6cd436a86ae63862f5a871723ebf9c540c48946f557ddbL39-R50) [[3]](diffhunk://#diff-853cf88526a68a37dc6cd436a86ae63862f5a871723ebf9c540c48946f557ddbL64-R67)
* Modified repository and data store interfaces and implementations to persist and retrieve the `symmetricKey` for both last connected and network devices (`AirSyncRepository.kt`, `AirSyncRepositoryImpl.kt`, `DataStoreManager.kt`). [[1]](diffhunk://#diff-308f7e5ca9dff826c138dc8830cd653b2d816551e667969ac2310627a9ea46dfL34-R34) [[2]](diffhunk://#diff-efe57e8efb3cd50977b307a6cbf2d4950aff8dcea1881dd54ddc23b932d6db8aL79-R80) [[3]](diffhunk://#diff-2749870d4e0c3e5bd01fde601b81cc1d4e683f8333e97f2dbfdf38129af48cf2R31) [[4]](diffhunk://#diff-2749870d4e0c3e5bd01fde601b81cc1d4e683f8333e97f2dbfdf38129af48cf2R136-R138) [[5]](diffhunk://#diff-2749870d4e0c3e5bd01fde601b81cc1d4e683f8333e97f2dbfdf38129af48cf2R156) [[6]](diffhunk://#diff-2749870d4e0c3e5bd01fde601b81cc1d4e683f8333e97f2dbfdf38129af48cf2L165-R171) [[7]](diffhunk://#diff-2749870d4e0c3e5bd01fde601b81cc1d4e683f8333e97f2dbfdf38129af48cf2L271-R277) [[8]](diffhunk://#diff-2749870d4e0c3e5bd01fde601b81cc1d4e683f8333e97f2dbfdf38129af48cf2R302-R304) [[9]](diffhunk://#diff-2749870d4e0c3e5bd01fde601b81cc1d4e683f8333e97f2dbfdf38129af48cf2R315) [[10]](diffhunk://#diff-2749870d4e0c3e5bd01fde601b81cc1d4e683f8333e97f2dbfdf38129af48cf2L326-R337) [[11]](diffhunk://#diff-2749870d4e0c3e5bd01fde601b81cc1d4e683f8333e97f2dbfdf38129af48cf2R363) [[12]](diffhunk://#diff-2749870d4e0c3e5bd01fde601b81cc1d4e683f8333e97f2dbfdf38129af48cf2L373-R386)
* Ensured the symmetric key is used during WebSocket connections, including in `ShareActivity` and the main screen. [[1]](diffhunk://#diff-fdf8bb78c9804ad876f3863d67377b3ba45c93cbff8de61d6802ea89f130766dL35-R46) [[2]](diffhunk://#diff-de07ef3d8e1abd4ac4e10a4d548cc754aa1a1319a9c14c148821c54316333807R127-R135) [[3]](diffhunk://#diff-de07ef3d8e1abd4ac4e10a4d548cc754aa1a1319a9c14c148821c54316333807R327)

**Version Update**

* Incremented app version from `2.0.9-BETA` to `2.0.10-BETA` in `build.gradle.kts`.