### PR TITLE
Develop

### DIFF
--- a/app/src/main/java/com/sameerasw/airsync/data/local/DataStoreManager.kt
+++ b/app/src/main/java/com/sameerasw/airsync/data/local/DataStoreManager.kt
@@ -52,6 +52,8 @@ class DataStoreManager(private val context: Context) {
         private val CONTINUE_BROWSING_ENABLED = booleanPreferencesKey("continue_browsing_enabled")
         // New: Send now playing toggle
         private val SEND_NOW_PLAYING_ENABLED = booleanPreferencesKey("send_now_playing_enabled")
+        // New: Keep previous link toggle
+        private val KEEP_PREVIOUS_LINK_ENABLED = booleanPreferencesKey("keep_previous_link_enabled")
 
         // Network-aware device connections
         private val NETWORK_DEVICES_PREFIX = "network_device_"
@@ -178,6 +180,19 @@ class DataStoreManager(private val context: Context) {
     fun getSendNowPlayingEnabled(): Flow<Boolean> {
         return context.dataStore.data.map { preferences ->
             preferences[SEND_NOW_PLAYING_ENABLED] != false // Default to enabled
+        }
+    }
+
+    // New: Keep previous link toggle
+    suspend fun setKeepPreviousLinkEnabled(enabled: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[KEEP_PREVIOUS_LINK_ENABLED] = enabled
+        }
+    }
+
+    fun getKeepPreviousLinkEnabled(): Flow<Boolean> {
+        return context.dataStore.data.map { preferences ->
+            preferences[KEEP_PREVIOUS_LINK_ENABLED] != false // Default to enabled
         }
     }
 

--- a/app/src/main/java/com/sameerasw/airsync/data/repository/AirSyncRepositoryImpl.kt
+++ b/app/src/main/java/com/sameerasw/airsync/data/repository/AirSyncRepositoryImpl.kt
@@ -141,6 +141,15 @@ class AirSyncRepositoryImpl(
         return dataStoreManager.getSendNowPlayingEnabled()
     }
 
+    // New: Keep previous link setting
+    override suspend fun setKeepPreviousLinkEnabled(enabled: Boolean) {
+        dataStoreManager.setKeepPreviousLinkEnabled(enabled)
+    }
+
+    override fun getKeepPreviousLinkEnabled(): Flow<Boolean> {
+        return dataStoreManager.getKeepPreviousLinkEnabled()
+    }
+
     override suspend fun setUserManuallyDisconnected(disconnected: Boolean) {
         dataStoreManager.setUserManuallyDisconnected(disconnected)
     }

--- a/app/src/main/java/com/sameerasw/airsync/domain/model/UiState.kt
+++ b/app/src/main/java/com/sameerasw/airsync/domain/model/UiState.kt
@@ -25,6 +25,7 @@ data class UiState(
     val manualIsPlus: Boolean = false,
     val isContinueBrowsingEnabled: Boolean = true,
     val isSendNowPlayingEnabled: Boolean = true,
+    val isKeepPreviousLinkEnabled: Boolean = true,
     // Mac device status
     val macDeviceStatus: MacDeviceStatus? = null,
     // Auth failure dialog

--- a/app/src/main/java/com/sameerasw/airsync/domain/repository/AirSyncRepository.kt
+++ b/app/src/main/java/com/sameerasw/airsync/domain/repository/AirSyncRepository.kt
@@ -60,6 +60,10 @@ interface AirSyncRepository {
     suspend fun setSendNowPlayingEnabled(enabled: Boolean)
     fun getSendNowPlayingEnabled(): Flow<Boolean>
 
+    // Keep previous link settings
+    suspend fun setKeepPreviousLinkEnabled(enabled: Boolean)
+    fun getKeepPreviousLinkEnabled(): Flow<Boolean>
+
     // User manual disconnect tracking
     suspend fun setUserManuallyDisconnected(disconnected: Boolean)
     fun getUserManuallyDisconnected(): Flow<Boolean>

--- a/app/src/main/java/com/sameerasw/airsync/presentation/ui/components/cards/ClipboardSyncCard.kt
+++ b/app/src/main/java/com/sameerasw/airsync/presentation/ui/components/cards/ClipboardSyncCard.kt
@@ -101,28 +101,6 @@ fun ClipboardSyncCard(
                 )
             }
 
-            // Send now playing toggle under Continue Browsing
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 12.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text("Send now playing", style = MaterialTheme.typography.titleMedium)
-                    Text(
-                        "Share media playback details (title, artist, artwork) with desktop",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-                Switch(
-                    checked = isSendNowPlayingEnabled,
-                    onCheckedChange = onToggleSendNowPlaying
-                )
-            }
-
             // Keep previous link toggle under Send now playing
             Row(
                 modifier = Modifier
@@ -145,6 +123,29 @@ fun ClipboardSyncCard(
                     enabled = isContinueBrowsingToggleEnabled
                 )
             }
+
+            // Send now playing toggle under Continue Browsing
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 12.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Send now playing", style = MaterialTheme.typography.titleMedium)
+                    Text(
+                        "Share media playback details (title, artist, artwork) with desktop",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Switch(
+                    checked = isSendNowPlayingEnabled,
+                    onCheckedChange = onToggleSendNowPlaying
+                )
+            }
+
         }
     }
 }

--- a/app/src/main/java/com/sameerasw/airsync/presentation/ui/components/cards/ClipboardSyncCard.kt
+++ b/app/src/main/java/com/sameerasw/airsync/presentation/ui/components/cards/ClipboardSyncCard.kt
@@ -31,6 +31,9 @@ fun ClipboardSyncCard(
     // New: Send now playing props
     isSendNowPlayingEnabled: Boolean,
     onToggleSendNowPlaying: (Boolean) -> Unit,
+    // New: Keep previous link props
+    isKeepPreviousLinkEnabled: Boolean,
+    onToggleKeepPreviousLink: (Boolean) -> Unit,
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -117,6 +120,29 @@ fun ClipboardSyncCard(
                 Switch(
                     checked = isSendNowPlayingEnabled,
                     onCheckedChange = onToggleSendNowPlaying
+                )
+            }
+
+            // Keep previous link toggle under Send now playing
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 12.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Keep previous link", style = MaterialTheme.typography.titleMedium)
+                    Text(
+                        "Keep multiple continue browsing notifications",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Switch(
+                    checked = isKeepPreviousLinkEnabled,
+                    onCheckedChange = onToggleKeepPreviousLink,
+                    enabled = isContinueBrowsingToggleEnabled
                 )
             }
         }

--- a/app/src/main/java/com/sameerasw/airsync/presentation/ui/screens/AirSyncMainScreen.kt
+++ b/app/src/main/java/com/sameerasw/airsync/presentation/ui/screens/AirSyncMainScreen.kt
@@ -468,7 +468,9 @@ fun AirSyncMainScreen(
                         isContinueBrowsingToggleEnabled = if (uiState.isConnected) uiState.lastConnectedDevice?.isPlus == true else true,
                         continueBrowsingSubtitle = "Prompt to open shared links with AirSync+",
                         isSendNowPlayingEnabled = uiState.isSendNowPlayingEnabled,
-                        onToggleSendNowPlaying = { enabled -> viewModel.setSendNowPlayingEnabled(enabled) }
+                        onToggleSendNowPlaying = { enabled -> viewModel.setSendNowPlayingEnabled(enabled) },
+                        isKeepPreviousLinkEnabled = uiState.isKeepPreviousLinkEnabled,
+                        onToggleKeepPreviousLink = { enabled -> viewModel.setKeepPreviousLinkEnabled(enabled) }
                     )
 
                     DeviceInfoCard(

--- a/app/src/main/java/com/sameerasw/airsync/presentation/viewmodel/AirSyncViewModel.kt
+++ b/app/src/main/java/com/sameerasw/airsync/presentation/viewmodel/AirSyncViewModel.kt
@@ -49,7 +49,10 @@ class AirSyncViewModel(
 
     private var appContext: Context? = null
     // Manual connect canceller reference (set in init) for unregistering
-    private val manualConnectCanceler: () -> Unit = { /* no-op */ }
+    private val manualConnectCanceler: () -> Unit = { 
+        // Cancel any active auto-reconnect when user starts manual connection
+        try { WebSocketUtil.cancelAutoReconnect() } catch (_: Exception) {}
+    }
 
     // Connection status listener for WebSocket updates
     private val connectionStatusListener: (Boolean) -> Unit = { isConnected ->

--- a/app/src/main/java/com/sameerasw/airsync/presentation/viewmodel/AirSyncViewModel.kt
+++ b/app/src/main/java/com/sameerasw/airsync/presentation/viewmodel/AirSyncViewModel.kt
@@ -156,6 +156,7 @@ class AirSyncViewModel(
             val lastConnectedSymmetricKey = lastConnected?.symmetricKey
             val isContinueBrowsingEnabled = repository.getContinueBrowsingEnabled().first()
             val isSendNowPlayingEnabled = repository.getSendNowPlayingEnabled().first()
+            val isKeepPreviousLinkEnabled = repository.getKeepPreviousLinkEnabled().first()
 
             // Get device info
             val deviceName = savedDeviceName.ifEmpty {
@@ -198,7 +199,8 @@ class AirSyncViewModel(
                 isConnected = currentlyConnected,
                 symmetricKey = symmetricKey ?: lastConnectedSymmetricKey,
                 isContinueBrowsingEnabled = isContinueBrowsingEnabled,
-                isSendNowPlayingEnabled = isSendNowPlayingEnabled
+                isSendNowPlayingEnabled = isSendNowPlayingEnabled,
+                isKeepPreviousLinkEnabled = isKeepPreviousLinkEnabled
             )
 
             // If we have PC name from QR code and not already connected, store it temporarily for the dialog
@@ -566,6 +568,13 @@ class AirSyncViewModel(
                 // Update media listener immediate behavior and sync status
                 com.sameerasw.airsync.service.MediaNotificationListener.setNowPlayingEnabled(ctx, enabled)
             }
+        }
+    }
+
+    fun setKeepPreviousLinkEnabled(enabled: Boolean) {
+        _uiState.value = _uiState.value.copy(isKeepPreviousLinkEnabled = enabled)
+        viewModelScope.launch {
+            repository.setKeepPreviousLinkEnabled(enabled)
         }
     }
 

--- a/app/src/main/java/com/sameerasw/airsync/utils/ClipboardSyncManager.kt
+++ b/app/src/main/java/com/sameerasw/airsync/utils/ClipboardSyncManager.kt
@@ -168,12 +168,13 @@ object ClipboardSyncManager {
             val dataStoreManager = DataStoreManager(context)
             syncScope.launch {
                 val continueEnabled = try { dataStoreManager.getContinueBrowsingEnabled().first() } catch (_: Exception) { true }
+                val keepPrevious = try { dataStoreManager.getKeepPreviousLinkEnabled().first() } catch (_: Exception) { true }
                 // Only for Plus and while connected
                 val isConnected = WebSocketUtil.isConnected()
                 val last = try { dataStoreManager.getLastConnectedDevice().first() } catch (_: Exception) { null }
                 val isPlus = last?.isPlus == true
                 if (continueEnabled && isConnected && isPlus && isLinkOnly(text)) {
-                    NotificationUtil.showContinueBrowsingLink(context, text.trim())
+                    NotificationUtil.showContinueBrowsingLink(context, text.trim(), keepPrevious)
                 }
             }
         } catch (e: Exception) {

--- a/app/src/main/java/com/sameerasw/airsync/utils/ClipboardSyncManager.kt
+++ b/app/src/main/java/com/sameerasw/airsync/utils/ClipboardSyncManager.kt
@@ -111,8 +111,42 @@ object ClipboardSyncManager {
     private fun isLinkOnly(text: String): Boolean {
         val trimmed = text.trim()
         if (trimmed.isEmpty()) return false
-        val matcher = Patterns.WEB_URL.matcher(trimmed)
-        return matcher.matches()
+        
+        // Split by whitespace to check if it's only a single token (no other text)
+        val tokens = trimmed.split("\\s+".toRegex())
+        if (tokens.size != 1) return false
+        
+        val url = tokens[0]
+        
+        // Check for explicit protocols
+        if (url.startsWith("http://", ignoreCase = true) || 
+            url.startsWith("https://", ignoreCase = true) ||
+            url.startsWith("ftp://", ignoreCase = true)) {
+            return true
+        }
+        
+        // Check for www prefix without protocol
+        if (url.startsWith("www.", ignoreCase = true)) {
+            return isValidDomainFormat(url.substring(4))
+        }
+        
+        // Check if it looks like a domain name (no protocol, no www)
+        return isValidDomainFormat(url)
+    }
+    
+    private fun isValidDomainFormat(domain: String): Boolean {
+        if (domain.isEmpty()) return false
+        
+        // Basic domain validation regex
+        // Matches: domain.com, sub.domain.com, domain.co.uk, etc.
+        val domainRegex = Regex(
+            "^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?" +
+            "(\\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*" +
+            "\\.[a-zA-Z]{2,}$",
+            RegexOption.IGNORE_CASE
+        )
+        
+        return domainRegex.matches(domain)
     }
 
     /**

--- a/app/src/main/java/com/sameerasw/airsync/utils/NotificationUtil.kt
+++ b/app/src/main/java/com/sameerasw/airsync/utils/NotificationUtil.kt
@@ -24,10 +24,12 @@ object NotificationUtil {
     private fun createContinueBrowsingChannel(context: Context) {
         val name = "Continue browsing"
         val descriptionText = "Quick open links received from desktop"
-        val importance = NotificationManager.IMPORTANCE_DEFAULT
+        val importance = NotificationManager.IMPORTANCE_LOW
         val channel = NotificationChannel(CONTINUE_CHANNEL_ID, name, importance).apply {
             description = descriptionText
-            setShowBadge(true)
+            setShowBadge(false)
+            setSound(null, null)
+            enableVibration(false)
         }
         val notificationManager: NotificationManager =
             context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
@@ -132,7 +134,8 @@ object NotificationUtil {
             .setStyle(NotificationCompat.BigTextStyle().bigText(trimmed))
             .setAutoCancel(true)
             .setCategory(NotificationCompat.CATEGORY_RECOMMENDATION)
-            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setSilent(true)
             .setContentIntent(openPending)
             .addAction(android.R.drawable.ic_menu_view, "Open", openPending)
             .addAction(android.R.drawable.ic_menu_close_clear_cancel, "Dismiss", dismissPending)

--- a/app/src/main/java/com/sameerasw/airsync/utils/NotificationUtil.kt
+++ b/app/src/main/java/com/sameerasw/airsync/utils/NotificationUtil.kt
@@ -99,10 +99,15 @@ object NotificationUtil {
     }
 
     // New: Continue Browsing notifications
-    fun showContinueBrowsingLink(context: Context, url: String) {
+    fun showContinueBrowsingLink(context: Context, url: String, keepPrevious: Boolean = true) {
         createContinueBrowsingChannel(context)
         val manager = NotificationManagerCompat.from(context)
         val notifId = (url.hashCode() and 0x7fffffff) // stable positive ID per URL
+
+        // If keepPrevious is false, clear all existing continue browsing notifications first
+        if (!keepPrevious) {
+            clearContinueBrowsingNotifications(context)
+        }
 
         // Normalize only for the open intent (keep text as-is)
         val trimmed = url.trim()

--- a/app/src/main/java/com/sameerasw/airsync/utils/WebSocketUtil.kt
+++ b/app/src/main/java/com/sameerasw/airsync/utils/WebSocketUtil.kt
@@ -259,17 +259,24 @@ object WebSocketUtil {
     }
 
     private fun isLocalNetwork(ipAddress: String): Boolean {
-        return ipAddress.startsWith("192.168.") ||
-                ipAddress.startsWith("10.") ||
-                ipAddress.startsWith("172.16.") ||
-                ipAddress.startsWith("172.17.") ||
-                ipAddress.startsWith("172.18.") ||
-                ipAddress.startsWith("172.19.") ||
-                ipAddress.startsWith("172.2") ||
-                ipAddress.startsWith("172.30.") ||
-                ipAddress.startsWith("172.31.") ||
-                ipAddress == "127.0.0.1" ||
-                ipAddress == "localhost"
+        // Check standard private IP ranges (RFC 1918)
+        if (ipAddress.startsWith("192.168.") || ipAddress.startsWith("10.")) {
+            return true
+        }
+        
+        // Check 172.16.0.0 to 172.31.255.255 range
+        if (ipAddress.startsWith("172.")) {
+            val parts = ipAddress.split(".")
+            if (parts.size >= 2) {
+                val secondOctet = parts[1].toIntOrNull()
+                if (secondOctet != null && secondOctet in 16..31) {
+                    return true
+                }
+            }
+        }
+        
+        // Check localhost
+        return ipAddress == "127.0.0.1" || ipAddress == "localhost"
     }
 
     fun sendMessage(message: String): Boolean {


### PR DESCRIPTION
This pull request introduces a new "Keep previous link" feature for continue browsing notifications, allowing users to choose whether multiple link notifications are kept or replaced. It also refines link detection logic, improves notification handling, and enhances local network IP detection for better reliability. The changes span UI, data storage, business logic, and utility classes.

**New Feature: Keep Previous Link Toggle**
- Added the `isKeepPreviousLinkEnabled` setting throughout the data layer (`DataStoreManager`, `AirSyncRepository`, and `UiState`), including persistence, retrieval, and exposure to the UI and ViewModel. [[1]](diffhunk://#diff-2749870d4e0c3e5bd01fde601b81cc1d4e683f8333e97f2dbfdf38129af48cf2R55-R56) [[2]](diffhunk://#diff-2749870d4e0c3e5bd01fde601b81cc1d4e683f8333e97f2dbfdf38129af48cf2R186-R198) [[3]](diffhunk://#diff-efe57e8efb3cd50977b307a6cbf2d4950aff8dcea1881dd54ddc23b932d6db8aR144-R152) [[4]](diffhunk://#diff-34503a06897da36e14844bf42209cb72337d23ca00cac7a029897b9aea186befR28) [[5]](diffhunk://#diff-308f7e5ca9dff826c138dc8830cd653b2d816551e667969ac2310627a9ea46dfR63-R66) [[6]](diffhunk://#diff-16e2711b11e71d6f9411c9307b5e0771d96bf2352592d798a9f5385a8145e894R159) [[7]](diffhunk://#diff-16e2711b11e71d6f9411c9307b5e0771d96bf2352592d798a9f5385a8145e894L198-R203) [[8]](diffhunk://#diff-16e2711b11e71d6f9411c9307b5e0771d96bf2352592d798a9f5385a8145e894R574-R580)
- Updated the UI components (`ClipboardSyncCard`, `AirSyncMainScreen`) to display the toggle and handle user interaction for the new setting. [[1]](diffhunk://#diff-df8291910d5b92a15875d631a162fe66b952bc189cf7ac9974bd4348ad76213dR34-R36) [[2]](diffhunk://#diff-df8291910d5b92a15875d631a162fe66b952bc189cf7ac9974bd4348ad76213dR104-R126) [[3]](diffhunk://#diff-df8291910d5b92a15875d631a162fe66b952bc189cf7ac9974bd4348ad76213dR148) [[4]](diffhunk://#diff-de07ef3d8e1abd4ac4e10a4d548cc754aa1a1319a9c14c148821c54316333807L471-R473)

**Clipboard Link Detection & Notification Logic**
- Improved link-only detection in `ClipboardSyncManager` to more accurately identify URLs, including protocol and domain validation.
- Modified notification logic to use the new setting, optionally clearing previous notifications when displaying a new link. [[1]](diffhunk://#diff-03c503ea0ca59f3f217ee4a15797036236817ffd29d746ab3c6ee34cfd1cc183R171-R177) [[2]](diffhunk://#diff-334c6f76e20333860afe09d08a130444417949e45f97feaa36ca5d6d940f395fL100-R111)

**Notification Experience Improvements**
- Changed continue browsing notification channel to lower importance, removed badge, disabled sound/vibration, and made notifications silent for less intrusive user experience. [[1]](diffhunk://#diff-334c6f76e20333860afe09d08a130444417949e45f97feaa36ca5d6d940f395fL27-R32) [[2]](diffhunk://#diff-334c6f76e20333860afe09d08a130444417949e45f97feaa36ca5d6d940f395fL135-R143)

**Networking Reliability**
- Refined local network IP detection in `WebSocketUtil` for more accurate handling of RFC 1918 ranges.

**Connection Management**
- Improved manual connection cancellation logic in `AirSyncViewModel` to ensure active auto-reconnect attempts are stopped when the user manually connects.