### PR TITLE
Web dav file access impl

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -154,6 +154,14 @@ dependencies {
 
     implementation(libs.wire.runtime)
     implementation(libs.bouncycastle)
+
+    // Ktor Server for WebDAV
+    implementation(libs.ktor.server.core)
+    implementation(libs.ktor.server.cio)
+    implementation(libs.ktor.server.host.common)
+    implementation(libs.ktor.server.status.pages)
+    implementation(libs.ktor.server.content.negotiation)
+    implementation(libs.ktor.serialization.gson)
 }
 
 wire {

--- a/app/src/main/java/com/sameerasw/airsync/data/local/DataStoreManager.kt
+++ b/app/src/main/java/com/sameerasw/airsync/data/local/DataStoreManager.kt
@@ -92,6 +92,7 @@ class DataStoreManager(private val context: Context) {
         private val PITCH_BLACK_THEME = booleanPreferencesKey("pitch_black_theme")
         private val SENTRY_REPORTING_ENABLED = booleanPreferencesKey("sentry_reporting_enabled")
         private val QUICK_SHARE_ENABLED = booleanPreferencesKey("quick_share_enabled")
+        private val FILE_ACCESS_ENABLED = booleanPreferencesKey("file_access_enabled")
 
         // Widget preferences
         private val WIDGET_TRANSPARENCY = androidx.datastore.preferences.core.floatPreferencesKey("widget_transparency")
@@ -343,6 +344,18 @@ class DataStoreManager(private val context: Context) {
     fun isQuickShareEnabled(): Flow<Boolean> {
         return context.dataStore.data.map { preferences ->
             preferences[QUICK_SHARE_ENABLED] ?: false // Default to disabled
+        }
+    }
+
+    suspend fun setFileAccessEnabled(enabled: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[FILE_ACCESS_ENABLED] = enabled
+        }
+    }
+
+    fun isFileAccessEnabled(): Flow<Boolean> {
+        return context.dataStore.data.map { preferences ->
+            preferences[FILE_ACCESS_ENABLED] != false // Default to enabled
         }
     }
 

--- a/app/src/main/java/com/sameerasw/airsync/data/repository/AirSyncRepositoryImpl.kt
+++ b/app/src/main/java/com/sameerasw/airsync/data/repository/AirSyncRepositoryImpl.kt
@@ -295,4 +295,12 @@ class AirSyncRepositoryImpl(
     override fun isQuickShareEnabled(): Flow<Boolean> {
         return dataStoreManager.isQuickShareEnabled()
     }
+
+    override suspend fun setFileAccessEnabled(enabled: Boolean) {
+        dataStoreManager.setFileAccessEnabled(enabled)
+    }
+
+    override fun isFileAccessEnabled(): Flow<Boolean> {
+        return dataStoreManager.isFileAccessEnabled()
+    }
 }

--- a/app/src/main/java/com/sameerasw/airsync/domain/model/UiState.kt
+++ b/app/src/main/java/com/sameerasw/airsync/domain/model/UiState.kt
@@ -50,5 +50,6 @@ data class UiState(
     val isOnboardingCompleted: Boolean = true,
     val widgetTransparency: Float = 1f,
     val isQuickShareEnabled: Boolean = false,
+    val isFileAccessEnabled: Boolean = true,
     val bleConnectionState: com.sameerasw.airsync.data.ble.BleGattServer.BleConnectionState = com.sameerasw.airsync.data.ble.BleGattServer.BleConnectionState.DISCONNECTED
 )

--- a/app/src/main/java/com/sameerasw/airsync/domain/repository/AirSyncRepository.kt
+++ b/app/src/main/java/com/sameerasw/airsync/domain/repository/AirSyncRepository.kt
@@ -132,4 +132,8 @@ interface AirSyncRepository {
     // Quick Share (receiving)
     suspend fun setQuickShareEnabled(enabled: Boolean)
     fun isQuickShareEnabled(): Flow<Boolean>
+
+    // File Access (WebDAV Server)
+    suspend fun setFileAccessEnabled(enabled: Boolean)
+    fun isFileAccessEnabled(): Flow<Boolean>
 }

--- a/app/src/main/java/com/sameerasw/airsync/presentation/ui/components/SettingsView.kt
+++ b/app/src/main/java/com/sameerasw/airsync/presentation/ui/components/SettingsView.kt
@@ -38,6 +38,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.sameerasw.airsync.R
 import com.sameerasw.airsync.domain.model.DeviceInfo
@@ -240,6 +241,16 @@ fun SettingsView(
                     isChecked = uiState.isQuickShareEnabled,
                     onCheckedChange = { enabled: Boolean ->
                         viewModel.setQuickShareEnabled(context, enabled)
+                    }
+                )
+
+                IconToggleItem(
+                    title = stringResource(R.string.label_file_access),
+                    description = stringResource(R.string.subtitle_file_access),
+                    iconRes = R.drawable.rounded_folder_managed_24,
+                    isChecked = uiState.isFileAccessEnabled,
+                    onCheckedChange = { enabled: Boolean ->
+                        viewModel.setFileAccessEnabled(context, enabled)
                     }
                 )
             }

--- a/app/src/main/java/com/sameerasw/airsync/presentation/viewmodel/AirSyncViewModel.kt
+++ b/app/src/main/java/com/sameerasw/airsync/presentation/viewmodel/AirSyncViewModel.kt
@@ -184,6 +184,13 @@ class AirSyncViewModel(
             }
         }
 
+        // Observe File Access preference
+        viewModelScope.launch {
+            repository.isFileAccessEnabled().collect { enabled ->
+                _uiState.value = _uiState.value.copy(isFileAccessEnabled = enabled)
+            }
+        }
+
         // Observe BLE connection status
         viewModelScope.launch {
             com.sameerasw.airsync.AirSyncApp.getBleConnectionManager()?.connectionState?.collect { state ->
@@ -688,6 +695,14 @@ class AirSyncViewModel(
             } else {
                 context.stopService(intent)
             }
+        }
+    }
+
+    fun setFileAccessEnabled(context: Context, enabled: Boolean) {
+        _uiState.value = _uiState.value.copy(isFileAccessEnabled = enabled)
+        viewModelScope.launch {
+            repository.setFileAccessEnabled(enabled)
+            ServiceManager.updateServiceState(context)
         }
     }
 

--- a/app/src/main/java/com/sameerasw/airsync/service/AirSyncService.kt
+++ b/app/src/main/java/com/sameerasw/airsync/service/AirSyncService.kt
@@ -17,8 +17,12 @@ import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.sameerasw.airsync.MainActivity
 import com.sameerasw.airsync.R
+import com.sameerasw.airsync.data.local.DataStoreManager
 import com.sameerasw.airsync.utils.DiscoveryMode
+import com.sameerasw.airsync.utils.MacDeviceStatusManager
+import com.sameerasw.airsync.utils.ShortcutUtil
 import com.sameerasw.airsync.utils.UDPDiscoveryManager
+import com.sameerasw.airsync.utils.WebDavServer
 import com.sameerasw.airsync.utils.WebSocketUtil
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -38,6 +42,8 @@ class AirSyncService : Service() {
     private var connectedDeviceName: String? = null
     private var isScanning = false
 
+    private var webDavServer: WebDavServer? = null
+
     // Network state tracking
     private var networkCallback: ConnectivityManager.NetworkCallback? = null
 
@@ -45,7 +51,7 @@ class AirSyncService : Service() {
         super.onCreate()
         Log.d(TAG, "AirSyncService created")
         createNotificationChannel()
-        com.sameerasw.airsync.utils.MacDeviceStatusManager.startMonitoring(this)
+        MacDeviceStatusManager.startMonitoring(this)
         registerNetworkCallback()
     }
 
@@ -58,7 +64,7 @@ class AirSyncService : Service() {
             ACTION_START_SYNC -> {
                 connectedDeviceName = intent.getStringExtra(EXTRA_DEVICE_NAME) ?: "Mac"
                 startSync()
-                com.sameerasw.airsync.utils.ShortcutUtil.refreshShortcuts(this, true)
+                ShortcutUtil.refreshShortcuts(this, true)
             }
 
             ACTION_STOP_SYNC -> stopSync()
@@ -83,7 +89,7 @@ class AirSyncService : Service() {
         startForeground(NOTIFICATION_ID, buildNotification())
 
         val dataStoreManager =
-            com.sameerasw.airsync.data.local.DataStoreManager.getInstance(applicationContext)
+            DataStoreManager.getInstance(applicationContext)
         val isDiscoveryEnabled = runBlocking {
             dataStoreManager.getDeviceDiscoveryEnabled().first()
         }
@@ -99,6 +105,18 @@ class AirSyncService : Service() {
 
         // Also trigger auto-reconnect logic to check if we already have a candidate
         WebSocketUtil.requestAutoReconnect(this)
+    }
+
+    private fun startWebDavServer() {
+        if (webDavServer == null) {
+            webDavServer = WebDavServer(this)
+        }
+        webDavServer?.start()
+    }
+
+    private fun stopWebDavServer() {
+        webDavServer?.stop()
+        webDavServer = null
     }
 
     private fun handleAppForeground() {
@@ -118,12 +136,16 @@ class AirSyncService : Service() {
     }
 
     private fun startSync() {
+        if (!isScanning && connectedDeviceName != null) {
+            Log.d(TAG, "AirSync foreground service already in sync state, ignoring")
+            return
+        }
         Log.d(TAG, "Starting AirSync foreground service (connected)")
         isScanning = false
         startForeground(NOTIFICATION_ID, buildNotification())
 
         val dataStoreManager =
-            com.sameerasw.airsync.data.local.DataStoreManager.getInstance(applicationContext)
+            DataStoreManager.getInstance(applicationContext)
         val isDiscoveryEnabled = runBlocking {
             dataStoreManager.getDeviceDiscoveryEnabled().first()
         }
@@ -134,11 +156,13 @@ class AirSyncService : Service() {
         UDPDiscoveryManager.setDiscoveryMode(this, DiscoveryMode.PASSIVE)
 
         WakeupService.startService(this)
+        startWebDavServer()
     }
 
     private fun stopSync() {
         Log.d(TAG, "Stopping AirSync foreground service")
-        com.sameerasw.airsync.utils.ShortcutUtil.refreshShortcuts(this, false)
+        stopWebDavServer()
+        ShortcutUtil.refreshShortcuts(this, false)
         UDPDiscoveryManager.stop(this)
         WakeupService.stopService(this)
         stopForeground(STOP_FOREGROUND_REMOVE)
@@ -234,8 +258,9 @@ class AirSyncService : Service() {
             }
         }
 
-        com.sameerasw.airsync.utils.MacDeviceStatusManager.stopMonitoring()
-        com.sameerasw.airsync.utils.MacDeviceStatusManager.cleanup(this)
+        stopWebDavServer()
+        MacDeviceStatusManager.stopMonitoring()
+        MacDeviceStatusManager.cleanup(this)
         scope.coroutineContext.cancel()
         super.onDestroy()
     }

--- a/app/src/main/java/com/sameerasw/airsync/service/AirSyncService.kt
+++ b/app/src/main/java/com/sameerasw/airsync/service/AirSyncService.kt
@@ -28,7 +28,9 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
 /**
@@ -43,6 +45,7 @@ class AirSyncService : Service() {
     private var isScanning = false
 
     private var webDavServer: WebDavServer? = null
+    private var webDavJob: Job? = null
 
     // Network state tracking
     private var networkCallback: ConnectivityManager.NetworkCallback? = null
@@ -119,6 +122,27 @@ class AirSyncService : Service() {
         webDavServer = null
     }
 
+    private fun monitorWebDavRequirements() {
+        webDavJob?.cancel()
+        webDavJob = scope.launch {
+            val dataStoreManager = DataStoreManager.getInstance(applicationContext)
+            combine(
+                dataStoreManager.isFileAccessEnabled(),
+                dataStoreManager.getLastConnectedDevice()
+            ) { isEnabled, device ->
+                Log.d(TAG, "WebDAV flow evaluation: isEnabled=$isEnabled, isPlus=${device?.isPlus}")
+                isEnabled && device?.isPlus == true
+            }.collect { shouldStart ->
+                Log.d(TAG, "WebDAV requirement state updated: shouldStart = $shouldStart")
+                if (shouldStart) {
+                    startWebDavServer()
+                } else {
+                    stopWebDavServer()
+                }
+            }
+        }
+    }
+
     private fun handleAppForeground() {
         if (isScanning) {
             Log.d(TAG, "App in foreground, switching to ACTIVE discovery")
@@ -156,11 +180,13 @@ class AirSyncService : Service() {
         UDPDiscoveryManager.setDiscoveryMode(this, DiscoveryMode.PASSIVE)
 
         WakeupService.startService(this)
-        startWebDavServer()
+        monitorWebDavRequirements()
     }
 
     private fun stopSync() {
         Log.d(TAG, "Stopping AirSync foreground service")
+        webDavJob?.cancel()
+        webDavJob = null
         stopWebDavServer()
         ShortcutUtil.refreshShortcuts(this, false)
         UDPDiscoveryManager.stop(this)

--- a/app/src/main/java/com/sameerasw/airsync/utils/WebDavServer.kt
+++ b/app/src/main/java/com/sameerasw/airsync/utils/WebDavServer.kt
@@ -1,0 +1,222 @@
+package com.sameerasw.airsync.utils
+
+import android.content.Context
+import android.os.Environment
+import android.util.Log
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.cio.*
+import io.ktor.server.engine.*
+import io.ktor.server.plugins.statuspages.*
+import io.ktor.server.request.path
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import java.io.File
+import java.net.ServerSocket
+import java.net.URLDecoder
+import java.text.SimpleDateFormat
+import java.util.*
+
+class WebDavServer(private val context: Context) {
+    private var engine: ApplicationEngine? = null
+    private val port = 9081
+    private val TAG = "WebDavServer"
+
+    private val storageRoot = Environment.getExternalStorageDirectory()
+
+    fun start() {
+        if (engine != null) {
+            Log.d(TAG, "WebDAV server already initialized")
+            return
+        }
+
+        if (!isPortAvailable(port)) {
+            Log.e(TAG, "WebDAV server cannot start: Port $port is already in use")
+            return
+        }
+
+        try {
+            engine = embeddedServer(CIO, port = port, host = "0.0.0.0") {
+                install(StatusPages) {
+                    exception<Throwable> { call, cause ->
+                        Log.e(TAG, "Unhandled exception in route", cause)
+                        call.respond(HttpStatusCode.InternalServerError, "Internal Server Error")
+                    }
+                }
+
+                routing {
+                    // Catch-all: matches any path including root
+                    route("{...}") {
+                        method(HttpMethod.parse("PROPFIND")) {
+                            handle { handlePropfind(call) }
+                        }
+                        get { handleGet(call) }
+                        head { handleHead(call) }
+                        method(HttpMethod.Options) {
+                            handle {
+                                call.response.header("Allow", "GET, HEAD, OPTIONS, PROPFIND")
+                                call.response.header("DAV", "1, 2")
+                                call.respond(HttpStatusCode.OK)
+                            }
+                        }
+                    }
+                }
+            }
+            engine?.start(wait = false)
+            Log.i(TAG, "WebDAV server started on port $port")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to start WebDAV server on port $port", e)
+            engine = null
+        }
+    }
+
+    private fun isPortAvailable(port: Int): Boolean {
+        return try {
+            ServerSocket(port).use { true }
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    fun stop() {
+        try {
+            engine?.stop(500, 1000)
+        } catch (e: Exception) {
+            Log.e(TAG, "Error stopping WebDAV server", e)
+        } finally {
+            engine = null
+            Log.i(TAG, "WebDAV server stopped")
+        }
+    }
+
+    /**
+     * Extracts the filesystem-relative path from the request URI.
+     * URL-decodes the path and strips the leading slash so it can be
+     * joined with storageRoot via File(storageRoot, relativePath).
+     * Trailing slashes are removed before file resolution.
+     */
+    private fun resolveRequestPath(call: ApplicationCall): String {
+        val raw = call.request.path() // e.g. "/", "/DCIM/", "/DCIM/Camera/IMG_001.jpg"
+        val decoded = URLDecoder.decode(raw, "UTF-8")
+        return decoded.trimStart('/').trimEnd('/')
+    }
+
+    private suspend fun handlePropfind(call: ApplicationCall) {
+        val relativePath = resolveRequestPath(call)
+        val file = File(storageRoot, relativePath)
+
+        Log.d(TAG, "PROPFIND: raw=${call.request.path()} -> resolved=${file.absolutePath}")
+
+        if (!file.exists()) {
+            Log.w(TAG, "PROPFIND 404: ${file.absolutePath}")
+            call.respond(HttpStatusCode.NotFound)
+            return
+        }
+
+        val depth = call.request.headers["Depth"] ?: "1"
+        val xml = buildPropfindXml(file, relativePath, depth)
+
+        call.respondText(xml, ContentType.Text.Xml.withParameter("charset", "utf-8"), HttpStatusCode.MultiStatus)
+    }
+
+    private fun buildPropfindXml(file: File, relativePath: String, depth: String): String {
+        val sb = StringBuilder()
+        sb.append("<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n")
+        sb.append("<d:multistatus xmlns:d=\"DAV:\">\n")
+
+        appendFileEntry(sb, file, relativePath)
+
+        if (file.isDirectory && depth != "0") {
+            file.listFiles()
+                ?.filter { !it.name.startsWith(".") }
+                ?.sortedWith(compareBy({ !it.isDirectory }, { it.name.lowercase() }))
+                ?.forEach { child ->
+                    val childRelPath = if (relativePath.isEmpty()) child.name else "$relativePath/${child.name}"
+                    appendFileEntry(sb, child, childRelPath)
+                }
+        }
+
+        sb.append("</d:multistatus>")
+        return sb.toString()
+    }
+
+    private fun appendFileEntry(sb: StringBuilder, file: File, relativePath: String) {
+        val displayName = if (relativePath.isEmpty()) "Android" else file.name
+
+        // Build the href: each path segment is percent-encoded individually,
+        // but the "/" separators are preserved. Root is always "/".
+        val href = if (relativePath.isEmpty()) {
+            "/"
+        } else {
+            val encodedSegments = relativePath.split("/").joinToString("/") { segment ->
+                segment.encodeURLPathPart()
+            }
+            // Directories must have trailing slash for WebDAV clients to recognise them
+            if (file.isDirectory) "/$encodedSegments/" else "/$encodedSegments"
+        }
+
+        val rfc1123Format = SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z", Locale.US).apply {
+            timeZone = TimeZone.getTimeZone("GMT")
+        }
+        val lastModified = rfc1123Format.format(Date(file.lastModified()))
+
+        sb.append("  <d:response>\n")
+        sb.append("    <d:href>$href</d:href>\n")
+        sb.append("    <d:propstat>\n")
+        sb.append("      <d:prop>\n")
+        sb.append("        <d:displayname>$displayName</d:displayname>\n")
+        if (file.isDirectory) {
+            sb.append("        <d:resourcetype><d:collection/></d:resourcetype>\n")
+        } else {
+            sb.append("        <d:resourcetype/>\n")
+            sb.append("        <d:getcontentlength>${file.length()}</d:getcontentlength>\n")
+            val contentType = java.net.URLConnection.guessContentTypeFromName(file.name) ?: "application/octet-stream"
+            sb.append("        <d:getcontenttype>$contentType</d:getcontenttype>\n")
+        }
+        sb.append("        <d:getlastmodified>$lastModified</d:getlastmodified>\n")
+        sb.append("      </d:prop>\n")
+        sb.append("      <d:status>HTTP/1.1 200 OK</d:status>\n")
+        sb.append("    </d:propstat>\n")
+        sb.append("  </d:response>\n")
+    }
+
+    private suspend fun handleGet(call: ApplicationCall) {
+        val relativePath = resolveRequestPath(call)
+        val file = File(storageRoot, relativePath)
+
+        Log.d(TAG, "GET: raw=${call.request.path()} -> resolved=${file.absolutePath}")
+
+        if (!file.exists()) {
+            call.respond(HttpStatusCode.NotFound)
+            return
+        }
+
+        if (file.isDirectory) {
+            call.respond(HttpStatusCode.MethodNotAllowed, "Cannot GET a directory")
+            return
+        }
+
+        call.respondFile(file)
+    }
+
+    private suspend fun handleHead(call: ApplicationCall) {
+        val relativePath = resolveRequestPath(call)
+        val file = File(storageRoot, relativePath)
+
+        if (!file.exists()) {
+            call.respond(HttpStatusCode.NotFound)
+            return
+        }
+
+        if (!file.isDirectory) {
+            call.response.header(HttpHeaders.ContentLength, file.length().toString())
+            val contentType = java.net.URLConnection.guessContentTypeFromName(file.name) ?: "application/octet-stream"
+            call.response.header(HttpHeaders.ContentType, contentType)
+        }
+        val rfc1123Format = SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z", Locale.US).apply {
+            timeZone = TimeZone.getTimeZone("GMT")
+        }
+        call.response.header(HttpHeaders.LastModified, rfc1123Format.format(Date(file.lastModified())))
+        call.respond(HttpStatusCode.OK)
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,4 +89,6 @@
     <string name="setting_auto_reconnect_desc">Attempted when disconnected unexpectedly</string>
     <string name="setting_nearby_connection_title">Switch to Nearby</string>
     <string name="setting_nearby_connection_desc">Use Bluetooth LE if connection lost</string>
+    <string name="label_file_access">File Access</string>
+    <string name="subtitle_file_access">Mount storage in macOS Finder</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ sentry = "8.0.0"
 protobuf = "4.28.2"
 wire = "6.0.0-alpha03"
 bouncycastle = "1.78.1"
+ktor = "2.3.12"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -54,6 +55,14 @@ play-review-ktx = { group = "com.google.android.play", name = "review-ktx", vers
 sentry-android = { group = "io.sentry", name = "sentry-android", version.ref = "sentry" }
 wire-runtime = { group = "com.squareup.wire", name = "wire-runtime", version.ref = "wire" }
 bouncycastle = { group = "org.bouncycastle", name = "bcprov-jdk18on", version.ref = "bouncycastle" }
+
+# Ktor Server for WebDAV
+ktor-server-core = { group = "io.ktor", name = "ktor-server-core", version.ref = "ktor" }
+ktor-server-cio = { group = "io.ktor", name = "ktor-server-cio", version.ref = "ktor" }
+ktor-server-host-common = { group = "io.ktor", name = "ktor-server-host-common", version.ref = "ktor" }
+ktor-server-status-pages = { group = "io.ktor", name = "ktor-server-status-pages", version.ref = "ktor" }
+ktor-server-content-negotiation = { group = "io.ktor", name = "ktor-server-content-negotiation", version.ref = "ktor" }
+ktor-serialization-gson = { group = "io.ktor", name = "ktor-serialization-gson", version.ref = "ktor" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
This pull request introduces support for a local WebDAV server in the app, allowing users to access their device's files over the network when certain conditions are met. It adds user-facing controls for enabling file access, implements the WebDAV server using Ktor, and integrates the server's lifecycle with the app's sync service and device state.

**WebDAV Server Integration:**

* Introduced a new `WebDavServer` class using Ktor, which exposes the device's external storage via WebDAV on port 9081. The server supports PROPFIND, GET, HEAD, and OPTIONS methods, providing directory listings and file downloads for compatible clients. (`app/src/main/java/com/sameerasw/airsync/utils/WebDavServer.kt`)
* Added Ktor server dependencies to the project to support the WebDAV server. (`app/build.gradle.kts`)

**Settings and User Preferences:**

* Added a new user preference (`file_access_enabled`) to control whether the WebDAV server is enabled. This includes repository, DataStore, and UI support, as well as a toggle in the settings screen. (`DataStoreManager.kt`, `AirSyncRepository.kt`, `AirSyncRepositoryImpl.kt`, `UiState.kt`, `SettingsView.kt`, `AirSyncViewModel.kt`) [[1]](diffhunk://#diff-2749870d4e0c3e5bd01fde601b81cc1d4e683f8333e97f2dbfdf38129af48cf2R95) [[2]](diffhunk://#diff-2749870d4e0c3e5bd01fde601b81cc1d4e683f8333e97f2dbfdf38129af48cf2R350-R361) [[3]](diffhunk://#diff-efe57e8efb3cd50977b307a6cbf2d4950aff8dcea1881dd54ddc23b932d6db8aR298-R305) [[4]](diffhunk://#diff-34503a06897da36e14844bf42209cb72337d23ca00cac7a029897b9aea186befR53) [[5]](diffhunk://#diff-308f7e5ca9dff826c138dc8830cd653b2d816551e667969ac2310627a9ea46dfR135-R138) [[6]](diffhunk://#diff-ea4cf2fa2da1c14ea2ea4c91fa409d111b2f57a52b328eaee4bb4ced503b5670R41) [[7]](diffhunk://#diff-ea4cf2fa2da1c14ea2ea4c91fa409d111b2f57a52b328eaee4bb4ced503b5670R246-R255) [[8]](diffhunk://#diff-16e2711b11e71d6f9411c9307b5e0771d96bf2352592d798a9f5385a8145e894R187-R193) [[9]](diffhunk://#diff-16e2711b11e71d6f9411c9307b5e0771d96bf2352592d798a9f5385a8145e894R701-R708)

**Service Lifecycle and Sync Integration:**

* The `AirSyncService` now starts and stops the WebDAV server based on the new preference and the connection state of a "Plus" device. It monitors these requirements reactively and ensures the server is only running when appropriate. (`AirSyncService.kt`) [[1]](diffhunk://#diff-87fac3e543a13273fabc7253e27665071cfa955a6a57dd397ccd116f43cd4257R20-R33) [[2]](diffhunk://#diff-87fac3e543a13273fabc7253e27665071cfa955a6a57dd397ccd116f43cd4257R47-R57) [[3]](diffhunk://#diff-87fac3e543a13273fabc7253e27665071cfa955a6a57dd397ccd116f43cd4257L61-R70) [[4]](diffhunk://#diff-87fac3e543a13273fabc7253e27665071cfa955a6a57dd397ccd116f43cd4257L86-R95) [[5]](diffhunk://#diff-87fac3e543a13273fabc7253e27665071cfa955a6a57dd397ccd116f43cd4257R113-R145) [[6]](diffhunk://#diff-87fac3e543a13273fabc7253e27665071cfa955a6a57dd397ccd116f43cd4257R163-R172) [[7]](diffhunk://#diff-87fac3e543a13273fabc7253e27665071cfa955a6a57dd397ccd116f43cd4257R183-R191) [[8]](diffhunk://#diff-87fac3e543a13273fabc7253e27665071cfa955a6a57dd397ccd116f43cd4257L237-R289)

These changes provide users with a secure and convenient way to access their files via WebDAV, while ensuring the server is only active when explicitly enabled and a compatible device is connected.