### PR TITLE
perf(android): optimize seekbar sync and filter out trivial media progress updates

### DIFF
--- a/app/src/main/java/com/sameerasw/airsync/service/MediaNotificationListener.kt
+++ b/app/src/main/java/com/sameerasw/airsync/service/MediaNotificationListener.kt
@@ -61,6 +61,19 @@ class MediaNotificationListener : NotificationListenerService() {
             SyncManager.checkAndSyncDeviceStatus(context, forceSync = true)
         }
 
+        fun hasSignificantMediaChange(old: MediaInfo?, new: MediaInfo?): Boolean {
+            if (old == null && new == null) return false
+            if (old == null || new == null) return true
+            return old.isPlaying != new.isPlaying ||
+                   old.title != new.title ||
+                   old.artist != new.artist ||
+                   old.albumArt != new.albumArt ||
+                   old.albumArtLite != new.albumArtLite ||
+                   old.durationMs != new.durationMs ||
+                   old.isBuffering != new.isBuffering ||
+                   old.likeStatus != new.likeStatus
+        }
+
         // In-memory cache of like status per track key
         private val likeStatusCache = LinkedHashMap<String, String>(32, 0.75f, true)
 
@@ -472,7 +485,7 @@ class MediaNotificationListener : NotificationListenerService() {
                 updateMediaInfo()
 
                 // If media info changed, trigger sync
-                if (previousMediaInfo != currentMediaInfo) {
+                if (hasSignificantMediaChange(previousMediaInfo, currentMediaInfo)) {
                     Log.d(TAG, "Media info changed, triggering sync")
                     SyncManager.onMediaStateChanged(this)
                 }
@@ -527,7 +540,7 @@ class MediaNotificationListener : NotificationListenerService() {
             updateMediaInfo()
 
             // If media info changed, trigger sync
-            if (previousMediaInfo != currentMediaInfo) {
+            if (hasSignificantMediaChange(previousMediaInfo, currentMediaInfo)) {
                 Log.d(TAG, "Media info changed after notification removal, triggering sync")
                 SyncManager.onMediaStateChanged(this)
             }


### PR DESCRIPTION


- Implement `hasSignificantMediaChange()` to perform deep metadata comparisons (playback state, title, artist, album art, buffering state, like status, and track duration).
- Ignore minor progress elapsed time ticks during comparison to eliminate the CPU-intensive, every-second WebSocket synchronization loop.
- Significantly reduce battery consumption, CPU overhead, and WebSocket network payloads on the Android client.